### PR TITLE
Switch to determinate-nix-action v3.13.2

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: DeterminateSystems/determinate-nix-action@v3.13.2
+        with:
+          github-token: ${{ github.token }}
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: DeterminateSystems/determinate-nix-action@v3.13.2
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: DeterminateSystems/determinate-nix-action@v3.13.2
+        with:
+          github-token: ${{ github.token }}
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: DeterminateSystems/determinate-nix-action@v3.13.2
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 


### PR DESCRIPTION
## Summary
- replace usage of DeterminateSystems/nix-installer-action with DeterminateSystems/determinate-nix-action version v3.13.2 in GitHub workflows

## Testing
- not run (CI workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c8edc02c48326b05fb17a732678b1)