### PR TITLE
Update workflows to determinate-nix-action v3.13.2

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: DeterminateSystems/determinate-nix-action@v3.13.2
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: DeterminateSystems/determinate-nix-action@v3.13.2
 
       - uses: DeterminateSystems/magic-nix-cache-action@main
 


### PR DESCRIPTION
## Summary
- replace nix-installer action with determinate-nix-action v3.13.2 in CI workflows

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c95b53c8c83268d022d8246b6418d)